### PR TITLE
fix(readme): correct typo in package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add to your Claude Desktop configuration file:
   "mcpServers": {
     "codex-cli": {
       "command": "npx",
-      "args": ["-y", "@comfuicos/codex-mcp-server"]
+      "args": ["-y", "@comfucios/codex-mcp-server"]
     }
   }
 }


### PR DESCRIPTION
Fixed a typo in the package name from "@comfuicos/codex-mcp-server" to "@comfucios/codex-mcp-server" in the configuration example.