### PR TITLE
docs: add documentation site and mkdocs config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+---
+name: docs
+on:
+  push:
+    branches: [main]
+  paths: [docs/**, mkdocs.yml]
+  workflow_dispatch: {}
+jobs:
+  build-deploy:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 1.0.1
+- Initial public release (comfucios fork)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,12 @@
+# Configuration
+
+Set these env vars in your editor/terminal as needed:
+
+```bash
+export OPENAI_API_KEY=...           # Required by Codex CLI unless logged in
+export CODEX_PAGE_SIZE=40000        # Optional default page size
+export CODEX_SESSION_TTL_MS=3600000 # Optional session TTL (ms)
+export CODEX_SESSION_MAX_BYTES=400000
+```
+
+> The server itself runs over **stdio** (Model Context Protocol). No ports required.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,21 @@
+# Development
+
+```bash
+npm i
+npm run dev     # tsx src/index.ts
+npm run build   # tsc → dist/
+npm start       # node dist/index.js
+```
+
+### Tests & linting
+
+```bash
+npm test
+npm run test:watch
+npm run test:coverage
+npm run lint
+npm run lint:fix
+npm run format
+```
+
+Project requires **Node ≥ 18.18**.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,13 @@
+# FAQ
+
+**Is this server stateful?**  
+Only if you pass `sessionId`. Otherwise, each call is stateless.
+
+**Can I run this without exposing an HTTP port?**  
+Yes—stdio transport only.
+
+**Does it support tool discovery?**  
+Yes—`ListTools` returns schemas for all tools.
+
+**How do I clear a session?**  
+Call `codex` with `{ "sessionId": "id", "resetSession": true, "prompt": "..." }`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# Codex MCP Server
+
+**MCP server wrapper for OpenAI Codex CLI that enables Claude Code to leverage Codex's AI capabilities directly.**
+
+```mermaid
+graph LR
+    A[Claude Code] --> B[Codex MCP Server]
+    B --> C[codex tool]
+    B --> H[listSessions tool]
+    B --> D[ping tool]
+    B --> E[help tool]
+    C --> F[Codex CLI]
+    F --> G[OpenAI API]
+    style A fill:#FF6B35
+    style B fill:#4A90E2
+    style C fill:#00D4AA
+    style D fill:#00D4AA
+    style E fill:#00D4AA
+    style F fill:#FFA500
+    style G fill:#FF9500
+    style H fill:#00D4AA
+```
+
+<div class="grid cards" markdown>
+
+-   :rocket: **One‑click install**
+    ---
+    [VS Code](https://vscode.dev/redirect/mcp/install?name=codex-cli&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40comfucios%2Fcodex-mcp-server%22%5D%7D) ·
+    [VS Code Insiders](https://insiders.vscode.dev/redirect/mcp/install?name=codex-cli&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40comfucios%2Fcodex-mcp-server%22%5D%7D) ·
+    [Cursor](https://cursor.com/en/install-mcp?name=codex&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IC15IEBjb21mdWNpb3MvY29kZXgtbWNwLXNlcnZlciIsImVudiI6e319)
+
+-   :gear: **MCP tools**
+    ---
+    `codex`, `listSessions`, `ping`, `help`
+
+-   :shield: **Requirements**
+    ---
+    - OpenAI Codex CLI (`npm i -g @openai/codex` or `brew install codex`)
+    - `codex login` or `OPENAI_API_KEY` set
+    - Claude Code or an MCP‑compatible client
+
+</div>

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,15 @@
+# Installation
+
+## One‑click buttons
+
+- [Install in VS Code](https://vscode.dev/redirect/mcp/install?name=codex-cli&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40comfucios%2Fcodex-mcp-server%22%5D%7D)
+- [Install in VS Code Insiders](https://insiders.vscode.dev/redirect/mcp/install?name=codex-cli&config=%7B%22type%22%3A%22stdio%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40comfucios%2Fcodex-mcp-server%22%5D%7D)
+- [Install in Cursor](https://cursor.com/en/install-mcp?name=codex&config=eyJ0eXBlIjoic3RkaW8iLCJjb21tYW5kIjoibnB4IC15IEBjb21mdWNpb3MvY29kZXgtbWNwLXNlcnZlciIsImVudiI6e319)
+
+## Manual
+
+```bash
+claude mcp add codex-cli -- npx -y @comfucios/codex-mcp-server
+```
+
+**Node ≥ 18.18** is required.

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,0 +1,9 @@
+# Pagination
+
+When output exceeds `pageSize`, the server returns the first slice plus a `nextPageToken`.
+
+1. Call with your initial prompt.
+2. If `nextPageToken` is present, call again with `{ "pageToken": "..." }`.
+3. Repeat until the token is no longer returned.
+
+Tokens expire after ~10 minutes of inactivity.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,31 @@
+# Quickstart
+
+## 1) Install prerequisites
+
+```bash
+npm i -g @openai/codex   # or: brew install codex
+codex login               # or export OPENAI_API_KEY=...
+```
+
+## 2) Add the server
+
+=== "Claude Code"
+```bash
+claude mcp add codex-cli -- npx -y @comfucios/codex-mcp-server
+```
+
+=== "Claude Desktop (macOS)"
+```json
+{
+  "mcpServers": {
+    "codex-cli": {
+      "command": "npx",
+      "args": ["-y", "@comfucios/codex-mcp-server"]
+    }
+  }
+}
+```
+
+## 3) Test connection
+
+Use the **ping** tool or ask the **codex** tool a simple prompt.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,20 @@
+# Tools API
+
+## codex
+
+Runs the local **Codex CLI** using streamed execution. The server strips prompt/context echoes and returns clean output. Large responses are paginated automatically.
+
+**Environment variables**
+
+- `CODEX_PAGE_SIZE` — default page size (min 1000, max 200000). Default: 40000.
+- `CODEX_SESSION_TTL_MS` — in‑memory session TTL (default 1 hour).
+- `CODEX_SESSION_MAX_BYTES` — max transcript bytes kept per session (~400 KB default).
+
+## listSessions
+Returns known session IDs.
+
+## ping
+Simple echo; defaults to `pong`.
+
+## help
+Prints `codex --help` for quick reference.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+## "Failed to start server"
+- Ensure Node ≥ 18.18.
+- Make sure `@openai/codex` is installed and `codex --version` works.
+
+## "Missing required 'prompt'"
+- First call must include `prompt` unless you’re passing a valid `pageToken`.
+
+## No output / partial output
+- Increase `pageSize` or follow the `nextPageToken`.
+- Very large outputs may take time; the CLI is streamed and then paginated.
+
+## Sessions not remembered
+- Pass a stable `sessionId`.
+- Session transcripts are trimmed when exceeding `CODEX_SESSION_MAX_BYTES` and expire after `CODEX_SESSION_TTL_MS`.
+
+## Windows shells
+- Prefer PowerShell or Git Bash; ensure `npx` is available on PATH.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,39 @@
+# Usage
+
+## Tools overview
+
+- **codex** — run the Codex CLI non‑interactively. Optional conversational context via `sessionId`.
+- **listSessions** — list active session IDs (managed in‑memory with TTL).
+- **ping** — echo test.
+- **help** — `codex --help` output passthrough.
+
+## Codex tool parameters
+
+| Name           | Type    | Default | Notes |
+|----------------|---------|---------|-------|
+| `prompt`       | string  | —       | Required on first call (unless paging). |
+| `pageSize`     | number  | 40000   | 1,000–200,000 chars. |
+| `pageToken`    | string  | —       | From previous paged response. |
+| `sessionId`    | string  | —       | Enables conversation memory within size limits. |
+| `resetSession` | boolean | false   | Clears given `sessionId` before running. |
+
+### Examples
+
+**Single‑shot**
+```json
+{ "prompt": "Explain this TypeScript function" }
+```
+
+**Paging through large output**
+```json
+{ "prompt": "Summarize this repository in depth" }
+```
+_Response includes_ `{ "nextPageToken": "abc..." }` → call again:
+```json
+{ "pageToken": "abc...", "pageSize": 40000 }
+```
+
+**Conversational**
+```json
+{ "sessionId": "issue-123", "prompt": "Draft tests for utils/sessionStore.ts" }
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: Codex MCP Server
+site_description: MCP server wrapper for OpenAI Codex CLI to let Claude Code leverage Codex.
+site_url: https://comfucios.github.io/codex-mcp-server/
+repo_url: https://github.com/CoMfUcIoS/codex-mcp-server
+repo_name: comfucios/codex-mcp-server
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.footer
+    - content.code.copy
+    - content.tabs.link
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: cyan
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: cyan
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+
+plugins:
+  - search
+
+nav:
+  - Overview: index.md
+  - Quickstart: quickstart.md
+  - Installation: install.md
+  - Usage: usage.md
+  - Tools API: tools.md
+  - Configuration: configuration.md
+  - Pagination: pagination.md
+  - Development: development.md
+  - Troubleshooting: troubleshooting.md
+  - FAQ: faq.md
+  - Changelog: changelog.md

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "format": "prettier --write src/**/*.ts",
     "format:check": "prettier --check src/**/*.ts",
     "clean": "rm -rf dist",
-    "prepublishOnly": "npm run clean && npm run build"
+    "prepublishOnly": "npm run clean && npm run build",
+    "docs:preview": "pip install mkdocs-material && mkdocs serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds initial documentation under the docs/ directory, including usage, installation, configuration, API reference, and troubleshooting guides. Introduces a GitHub Actions workflow for building and deploying docs to GitHub Pages using MkDocs Material. Adds mkdocs.yml for site config and a docs:preview npm script for local preview.